### PR TITLE
Add test for malformed update error with NODE bit set

### DIFF
--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -24,7 +24,7 @@ use ln::channelmanager::{ChannelManager, ChannelManagerReadArgs, PaymentId, RAAC
 use ln::channel::{Channel, ChannelError};
 use ln::{chan_utils, onion_utils};
 use ln::chan_utils::{htlc_success_tx_weight, htlc_timeout_tx_weight, HTLCOutputInCommitment};
-use routing::gossip::NetworkGraph;
+use routing::gossip::{NetworkGraph, NetworkUpdate};
 use routing::router::{PaymentParameters, Route, RouteHop, RouteParameters, find_route, get_route};
 use ln::features::{ChannelFeatures, InitFeatures, InvoiceFeatures, NodeFeatures};
 use ln::msgs;
@@ -7179,6 +7179,100 @@ fn test_update_fulfill_htlc_bolt2_after_malformed_htlc_message_must_forward_upda
 	};
 
 	check_added_monitors!(nodes[1], 1);
+}
+
+#[test]
+fn test_channel_failed_after_message_with_badonion_node_perm_bits_set() {
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let mut nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000,
+		InitFeatures::known(), InitFeatures::known());
+	let chan_2 = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1000000, 1000000,
+		InitFeatures::known(), InitFeatures::known());
+
+	let (route, our_payment_hash, _, our_payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[2], 100000);
+
+	// First hop
+	let mut payment_event = {
+		nodes[0].node.send_payment(&route, our_payment_hash, &Some(our_payment_secret)).unwrap();
+		check_added_monitors!(nodes[0], 1);
+		let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+	nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &payment_event.msgs[0]);
+	check_added_monitors!(nodes[1], 0);
+	commitment_signed_dance!(nodes[1], nodes[0], payment_event.commitment_msg, false);
+	expect_pending_htlcs_forwardable!(nodes[1]);
+	let mut events_2 = nodes[1].node.get_and_clear_pending_msg_events();
+	assert_eq!(events_2.len(), 1);
+	check_added_monitors!(nodes[1], 1);
+	payment_event = SendEvent::from_event(events_2.remove(0));
+	assert_eq!(payment_event.msgs.len(), 1);
+
+	// Second Hop
+	payment_event.msgs[0].onion_routing_packet.version = 1; // Trigger an invalid_onion_version error
+	nodes[2].node.handle_update_add_htlc(&nodes[1].node.get_our_node_id(), &payment_event.msgs[0]);
+	check_added_monitors!(nodes[2], 0);
+	commitment_signed_dance!(nodes[2], nodes[1], payment_event.commitment_msg, false, true);
+
+	let events_3 = nodes[2].node.get_and_clear_pending_msg_events();
+	assert_eq!(events_3.len(), 1);
+	let update_msg : (msgs::UpdateFailMalformedHTLC, msgs::CommitmentSigned) = {
+		match events_3[0] {
+			MessageSendEvent::UpdateHTLCs { node_id: _ , updates: msgs::CommitmentUpdate {
+				ref update_fail_malformed_htlcs, ref commitment_signed, .. } } => {
+				let mut update_msg = update_fail_malformed_htlcs[0].clone();
+				// Set the NODE bit (BADONION and PERM already set in invalid_onion_version error)
+				update_msg.failure_code = update_msg.failure_code|0x2000;
+				(update_msg, commitment_signed.clone())
+			},
+			_ => panic!("Unexpected event"),
+		}
+	};
+
+	nodes[1].node.handle_update_fail_malformed_htlc(&nodes[2].node.get_our_node_id(), &update_msg.0);
+
+	check_added_monitors!(nodes[1], 0);
+	commitment_signed_dance!(nodes[1], nodes[2], update_msg.1, false, true);
+	expect_pending_htlcs_forwardable_and_htlc_handling_failed!(nodes[1],
+		vec![HTLCDestination::NextHopChannel {
+			node_id: Some(nodes[2].node.get_our_node_id()), channel_id: chan_2.2 }]);
+	let events_4 = nodes[1].node.get_and_clear_pending_msg_events();
+	assert_eq!(events_4.len(), 1);
+	check_added_monitors!(nodes[1], 1);
+
+	let update_msg: (msgs::UpdateFailHTLC, msgs::CommitmentSigned) = {
+		match events_4[0] {
+			MessageSendEvent::UpdateHTLCs { node_id: _ , updates: msgs::CommitmentUpdate {
+				ref update_fail_htlcs, ref commitment_signed, .. } } => {
+				(update_fail_htlcs[0].clone(), commitment_signed.clone())
+			},
+			_ => panic!("Unexpected event"),
+		}
+	};
+
+	nodes[0].node.handle_update_fail_htlc(&nodes[1].node.get_our_node_id(), &update_msg.0);
+
+	check_added_monitors!(nodes[0], 0);
+	commitment_signed_dance!(nodes[0], nodes[1], update_msg.1, false, true);
+	let events_5 = nodes[0].node.get_and_clear_pending_events();
+	assert_eq!(events_5.len(), 1);
+
+	// Expect a PaymentPathFailed event with a ChannelFailure network update for the channel between
+	// the node originating the error to its next hop.
+	match events_5[0] {
+		Event::PaymentPathFailed { network_update: Some(NetworkUpdate::ChannelFailure {
+			short_channel_id, is_permanent }), .. } => {
+			assert_eq!(short_channel_id, chan_2.0.contents.short_channel_id);
+			assert!(is_permanent);
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	// TODO: Test actual removal of channel from NetworkGraph when it's implemented.
 }
 
 fn do_test_failure_delay_dust_htlc_local_commitment(announce_latest: bool) {


### PR DESCRIPTION
Think this is the easiest way to get it into your PR other than a manual patch.